### PR TITLE
Support Themeify's dark themes

### DIFF
--- a/octoprint_terminalmessaging/static/css/terminalmessaging.css
+++ b/octoprint_terminalmessaging/static/css/terminalmessaging.css
@@ -11,6 +11,13 @@
     display: block;
 }
 
+.themeify.discorded #terminal-output span.received,
+.themeify.discoranged #terminal-output span.received,
+.themeify.cyborg #terminal-output span.received,
+.themeify.nighttime #terminal-output span.received {
+    color: lightskyblue;
+}
+
 #terminal-output span.sent {
     position: relative;
     font-size: 18px;
@@ -18,4 +25,11 @@
     text-align: right;
     color: green;
     display: block;
+}
+
+.themeify.discorded #terminal-output span.sent,
+.themeify.discoranged #terminal-output span.sent,
+.themeify.cyborg #terminal-output span.sent,
+.themeify.nighttime #terminal-output span.sent {
+    color: greenyellow;
 }


### PR DESCRIPTION
The colours clash with a dark background, so some lighter shades are used

Before:
![terminal-messaging-before](https://user-images.githubusercontent.com/2470905/94866933-24fa5f80-0438-11eb-8039-b073d826ed40.png)

After:
![terminal-messaging-after](https://user-images.githubusercontent.com/2470905/94866985-3e9ba700-0438-11eb-8f82-76d25e219baf.png)
